### PR TITLE
ADD: Prevent on Click for <a> tag in Pager Button

### DIFF
--- a/src/vue-datatable-pager-button.vue
+++ b/src/vue-datatable-pager-button.vue
@@ -2,7 +2,7 @@
 
 <template>
 	<li :class="li_classes">
-		<a href="javascript: void(0);" :class="a_classes" @click="sendClick">
+		<a href="javascript: void(0);" :class="a_classes" @click.prevent="sendClick">
 			<slot>{{ value }}</slot>
 		</a>
 	</li>


### PR DESCRIPTION
Added prevent on @click for <a> tag in Pager Button. 
This resolve problem with "creating new tab" in Mozilla - by clicking on pager button.
`<a href="javascript: void(0);" :class="a_classes" @click**.prevent**="sendClick">`